### PR TITLE
Exporter: Fix camera FOV when output is vertical

### DIFF
--- a/mitsuba-blender/engine/final.py
+++ b/mitsuba-blender/engine/final.py
@@ -39,7 +39,7 @@ class MitsubaRenderEngine(bpy.types.RenderEngine):
             with tempfile.TemporaryDirectory() as dummy_dir:
                 filepath = os.path.join(dummy_dir, "scene.xml")
                 self.converter.set_path(filepath)
-                self.converter.scene_to_dict(depsgraph, bpy.context.window_manager)
+                self.converter.scene_to_dict(depsgraph)
                 Thread.thread().file_resolver().prepend(dummy_dir)
                 mts_scene = self.converter.dict_to_scene()
 

--- a/mitsuba-blender/engine/final.py
+++ b/mitsuba-blender/engine/final.py
@@ -39,7 +39,7 @@ class MitsubaRenderEngine(bpy.types.RenderEngine):
             with tempfile.TemporaryDirectory() as dummy_dir:
                 filepath = os.path.join(dummy_dir, "scene.xml")
                 self.converter.set_path(filepath)
-                self.converter.scene_to_dict(depsgraph)
+                self.converter.scene_to_dict(depsgraph, bpy.context.window_manager)
                 Thread.thread().file_resolver().prepend(dummy_dir)
                 mts_scene = self.converter.dict_to_scene()
 

--- a/mitsuba-blender/io/exporter/camera.py
+++ b/mitsuba-blender/io/exporter/camera.py
@@ -14,8 +14,8 @@ def export_camera(camera_instance, b_scene, export_ctx):
     # Extract fov
     sensor_fit = b_camera.data.sensor_fit
     if sensor_fit == 'AUTO':
-        params['fov_axis'] = 'x'
-        params['fov'] = degrees(b_camera.data.angle_x if res_x >= res_y else b_camera.data.angle_y)
+        params['fov_axis'] = 'x' if res_x >= res_y else 'y'
+        params['fov'] = degrees(b_camera.data.angle_x)
     elif sensor_fit == 'HORIZONTAL':
         params['fov_axis'] = 'x'
         params['fov'] = degrees(b_camera.data.angle_x)


### PR DESCRIPTION
This PR fixes #25.

Blender uses the `sensor_fit` parameter to determine how to fit the
sensor inside of the output image dimension. By default, it is set to
`AUTO` which swaps x and y FOV axis depending on which side of the image
is largest.

Previously, we did not take that parameter into account, resulting in
invalid results for tall images.

More information on how this parameter is used by Blender can be found [here](https://docs.blender.org/manual/en/latest/render/cameras.html#camera).