### PR TITLE
Export: Add principal point exporting in camera.py

### DIFF
--- a/mitsuba-blender/io/exporter/camera.py
+++ b/mitsuba-blender/io/exporter/camera.py
@@ -25,6 +25,9 @@ def export_camera(camera_instance, b_scene, export_ctx):
     else:
         export_ctx.log(f'Unknown \'sensor_fit\' value when exporting camera: {sensor_fit}', 'ERROR')
 
+    params["principal_point_offset_x"] = b_camera.data.shift_x
+    params["principal_point_offset_y"] = -b_camera.data.shift_y / res_x * res_y
+
     #TODO: test other parameters relevance (camera.lens, orthographic_scale, dof...)
     params['near_clip'] = b_camera.data.clip_start
     params['far_clip'] = b_camera.data.clip_end

--- a/mitsuba-blender/io/exporter/camera.py
+++ b/mitsuba-blender/io/exporter/camera.py
@@ -25,8 +25,8 @@ def export_camera(camera_instance, b_scene, export_ctx):
     else:
         export_ctx.log(f'Unknown \'sensor_fit\' value when exporting camera: {sensor_fit}', 'ERROR')
 
-    params["principal_point_offset_x"] = b_camera.data.shift_x
-    params["principal_point_offset_y"] = -b_camera.data.shift_y / res_x * res_y
+    params["principal_point_offset_x"] = b_camera.data.shift_x / res_x * max(res_x, res_y)
+    params["principal_point_offset_y"] = -b_camera.data.shift_y / res_y * max(res_x, res_y)
 
     #TODO: test other parameters relevance (camera.lens, orthographic_scale, dof...)
     params['near_clip'] = b_camera.data.clip_start


### PR DESCRIPTION
Currently, principal point is not being exported. It is assumed to be in the center of the image, disregarding the settings in Blender.