### PR TITLE
Installation: Print exception stacktrace when failing to import Mitsuba

### DIFF
--- a/mitsuba-blender/__init__.py
+++ b/mitsuba-blender/__init__.py
@@ -19,6 +19,7 @@ from bpy.utils import register_class, unregister_class
 import os
 import sys
 import subprocess
+import traceback
 
 from . import io, engine
 
@@ -40,7 +41,11 @@ def init_mitsuba(context):
         bpy.types.Scene.thread_env = ThreadEnvironment()
         return True
     except ModuleNotFoundError:
-        return False
+        pass
+    except Exception:
+        print('Failed to initialize mitsuba-blender add-on with exception:')
+        traceback.print_exc()
+    return False
 
 def try_register_mitsuba(context):
     prefs = get_addon_preferences(context)
@@ -225,7 +230,7 @@ class MitsubaPreferences(AddonPreferences):
             self.mitsuba_dependencies_status_message = 'A restart is required to apply the changes.'
             row.alert = True
             icon = 'ERROR'
-        elif self.has_pip_package or self.has_valid_mitsuba_custom_path:
+        elif (self.has_pip_package or self.has_valid_mitsuba_custom_path) and self.is_mitsuba_initialized:
             icon = 'CHECKMARK'
         else:
             icon = 'CANCEL'

--- a/mitsuba-blender/io/importer/mi_spectra_utils.py
+++ b/mitsuba-blender/io/importer/mi_spectra_utils.py
@@ -30,7 +30,7 @@ def convert_mi_srgb_reflectance_spectrum(mi_obj, default):
 #######################
 
 def convert_mi_srgb_emitter_spectrum(mi_obj, default):
-    assert mi_obj.class_().name() == 'SRGBEmitterSpectrum'
+    assert mi_obj.class_().name() == 'SRGBReflectanceSpectrum' or mi_obj.class_().name() == 'SRGBEmitterSpectrum'
     obj_props = _get_mi_obj_properties(mi_obj)
     radiance = list(obj_props.get('value', default))
     return get_color_strength_from_radiance(radiance)


### PR DESCRIPTION
We now print the full stacktrace of exceptions that occur when failing to import the `mitsuba` package installed from pip.

This can help solve problems, such as the ones brought up in #38.