### PR TITLE
Installation: Define a fixed version for Mitsuba dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           version: "2.93"
         }
         - {
-          version: "3.1"
+          version: "3.3"
         }
         
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,12 @@ jobs:
       matrix:
         environment:
         - {
-          os: "ubuntu-latest"
+          os: "ubuntu-latest",
+          mitsuba-version: "3.0.1"
         }
         - {
-          os: "windows-latest"
+          os: "windows-latest",
+          mitsuba-version: "3.0.1"
         }
         blender:
         - {
@@ -71,7 +73,8 @@ jobs:
         echo "Blender Python is $BLENDER_PYTHON"
         ./$BLENDER_PYTHON -m ensurepip
         ./$BLENDER_PYTHON -m pip install -U pip
-        ./$BLENDER_PYTHON -m pip install --upgrade pytest pytest-cov mitsuba
+        ./$BLENDER_PYTHON -m pip install --upgrade pytest pytest-cov
+        ./$BLENDER_PYTHON -m pip install mitsuba==${{ matrix.environment.mitsuba-version }} --force-reinstall
 
     - name: Run Addon test suite
       shell: bash

--- a/mitsuba-blender/__init__.py
+++ b/mitsuba-blender/__init__.py
@@ -22,12 +22,15 @@ import subprocess
 
 from . import io, engine
 
+DEPS_MITSUBA_VERSION = '3.0.1'
+
 def get_addon_preferences(context):
     return context.preferences.addons[__name__].preferences
 
 def init_mitsuba(context):
     # Make sure we can load mitsuba from blender
     try:
+        os.environ['DRJIT_NO_RTLD_DEEPBIND'] = 'True'
         should_reload_mitsuba = 'mitsuba' in sys.modules
         import mitsuba
         # If mitsuba was already loaded and we change the path, we need to reload it, since the import above will be ignored
@@ -50,19 +53,25 @@ def try_register_mitsuba(context):
     if prefs.using_mitsuba_custom_path:
         update_additional_custom_paths(prefs, context)
         could_init_mitsuba = init_mitsuba(context)
-        prefs.has_valid_mitsuba_custom_path = could_init_mitsuba
         if could_init_mitsuba:
             import mitsuba
-            prefs.mitsuba_dependencies_status_message = f'Found custom Mitsuba v{mitsuba.__version__}.'
+            prefs.mitsuba_custom_version = mitsuba.__version__
+            if prefs.has_valid_mitsuba_custom_version:
+                prefs.mitsuba_dependencies_status_message = f'Found custom Mitsuba v{prefs.mitsuba_custom_version}.'
+            else:
+                prefs.mitsuba_dependencies_status_message = f'Found custom Mitsuba v{prefs.mitsuba_custom_version}. Supported version is v{DEPS_MITSUBA_VERSION}.'
         else:
             prefs.mitsuba_dependencies_status_message = 'Failed to load custom Mitsuba. Please verify the path to the build directory.'
-    elif prefs.has_pip_package:
-        could_init_mitsuba = init_mitsuba(context)
-        if could_init_mitsuba:
-            import mitsuba
-            prefs.mitsuba_dependencies_status_message = f'Found pip Mitsuba v{mitsuba.__version__}.'
+    elif prefs.has_pip_dependencies:
+        if prefs.has_valid_dependencies_version:
+            could_init_mitsuba = init_mitsuba(context)
+            if could_init_mitsuba:
+                import mitsuba
+                prefs.mitsuba_dependencies_status_message = f'Found pip Mitsuba v{mitsuba.__version__}.'
+            else:
+                prefs.mitsuba_dependencies_status_message = 'Failed to load Mitsuba package.'
         else:
-            prefs.mitsuba_dependencies_status_message = 'Failed to load Mitsuba package.'
+            prefs.mitsuba_dependencies_status_message = f'Found pip Mitsuba v{prefs.installed_dependencies_version}. Supported version is v{DEPS_MITSUBA_VERSION}.'
     else:
         prefs.mitsuba_dependencies_status_message = 'Mitsuba dependencies not installed.'
 
@@ -98,8 +107,19 @@ def ensure_pip():
 
 def check_pip_dependencies(context):
     prefs = get_addon_preferences(context)
-    result = subprocess.run([sys.executable, '-m', 'pip', 'show', 'mitsuba'], capture_output=True)
-    prefs.has_pip_package = result.returncode == 0
+    result = subprocess.run([sys.executable, '-m', 'pip', 'list'], capture_output=True)
+    
+    prefs.has_pip_dependencies = False
+    prefs.has_valid_dependencies_version = False
+
+    if result.returncode == 0:
+        output_str = result.stdout.decode('utf-8')
+        lines = output_str.splitlines(keepends=False)
+        for line in lines:
+            parts = line.split()
+            if len(parts) >= 2 and parts[0] == 'mitsuba':
+                prefs.has_pip_dependencies = True
+                prefs.installed_dependencies_version = parts[1]
 
 def clean_additional_custom_paths(self, context):
     # Remove old values from system PATH and sys.path
@@ -135,24 +155,22 @@ class MITSUBA_OT_install_pip_dependencies(Operator):
     @classmethod
     def poll(cls, context):
         prefs = get_addon_preferences(context)
-        return not prefs.has_pip_package
+        return not prefs.has_pip_dependencies or not prefs.has_valid_dependencies_version
 
     def execute(self, context):
-        result = subprocess.run([sys.executable, '-m', 'pip', 'install', 'mitsuba'], capture_output=True)
+        result = subprocess.run([sys.executable, '-m', 'pip', 'install', f'mitsuba=={DEPS_MITSUBA_VERSION}', '--force-reinstall'], capture_output=False)
         if result.returncode != 0:
             self.report({'ERROR'}, f'Failed to install Mitsuba with return code {result.returncode}.')
             return {'CANCELLED'} 
 
-        prefs = get_addon_preferences(context)
-        prefs.has_pip_package = True
+        check_pip_dependencies(context)
 
         try_reload_mitsuba(context)
 
         return {'FINISHED'}
 
 def update_using_mitsuba_custom_path(self, context):
-    if self.is_mitsuba_initialized:
-        self.require_restart = True
+    self.require_restart = True
     if self.using_mitsuba_custom_path:
         update_mitsuba_custom_path(self, context)
     else:
@@ -166,6 +184,12 @@ def update_mitsuba_custom_path(self, context):
         if not self.is_mitsuba_initialized:
             try_reload_mitsuba(context)
 
+def update_installed_dependencies_version(self, context):
+    self.has_valid_dependencies_version = self.installed_dependencies_version == DEPS_MITSUBA_VERSION
+
+def update_mitsuba_custom_version(self, context):
+    self.has_valid_mitsuba_custom_version = self.mitsuba_custom_version == DEPS_MITSUBA_VERSION
+
 class MitsubaPreferences(AddonPreferences):
     bl_idname = __name__
 
@@ -173,8 +197,18 @@ class MitsubaPreferences(AddonPreferences):
         name = 'Is Mitsuba initialized',
     )
 
-    has_pip_package : BoolProperty(
+    has_pip_dependencies : BoolProperty(
         name = 'Has pip dependencies installed',
+    )
+
+    installed_dependencies_version : StringProperty(
+        name = 'Installed Mitsuba dependencies version string',
+        default = '',
+        update = update_installed_dependencies_version,
+    )
+
+    has_valid_dependencies_version : BoolProperty(
+        name = 'Has the correct version of dependencies'
     )
 
     mitsuba_dependencies_status_message : StringProperty(
@@ -193,16 +227,22 @@ class MitsubaPreferences(AddonPreferences):
         update = update_using_mitsuba_custom_path,
     )
 
-    has_valid_mitsuba_custom_path : BoolProperty(
-        name = 'Has valid custom Mitsuba path',
-    )
-
     mitsuba_custom_path : StringProperty(
         name = 'Custom Mitsuba path',
         description = 'Path to the custom Mitsuba build directory',
         default = '',
         subtype = 'DIR_PATH',
         update = update_mitsuba_custom_path,
+    )
+
+    mitsuba_custom_version : StringProperty(
+        name = 'Custom Mitsuba build version',
+        default = '',
+        update = update_mitsuba_custom_version,
+    )
+
+    has_valid_mitsuba_custom_version : BoolProperty(
+        name = 'Has the correct version of custom Mitsuba build'
     )
 
     additional_path : StringProperty(
@@ -221,22 +261,23 @@ class MitsubaPreferences(AddonPreferences):
         layout = self.layout
 
         row = layout.row()
+        icon = 'ERROR'
+        row.alert = True
         if self.require_restart:
             self.mitsuba_dependencies_status_message = 'A restart is required to apply the changes.'
-            row.alert = True
-            icon = 'ERROR'
-        elif self.has_pip_package or self.has_valid_mitsuba_custom_path:
+        elif self.is_mitsuba_initialized and (not self.using_mitsuba_custom_path or (self.using_mitsuba_custom_path and self.has_valid_mitsuba_custom_version)):
             icon = 'CHECKMARK'
-        else:
-            icon = 'CANCEL'
-            row.alert = True
+            row.alert = False
         row.label(text=self.mitsuba_dependencies_status_message, icon=icon)
 
-        layout.operator(MITSUBA_OT_install_pip_dependencies.bl_idname, text='Install dependencies using pip')
+        operator_text = 'Install dependencies'
+        if self.has_pip_dependencies and not self.has_valid_dependencies_version:
+            operator_text = 'Update dependencies'
+        layout.operator(MITSUBA_OT_install_pip_dependencies.bl_idname, text=operator_text)
 
         box = layout.box()
         box.label(text='Advanced Settings')
-        box.prop(self, 'using_mitsuba_custom_path', text='Use custom Mitsuba path')
+        box.prop(self, 'using_mitsuba_custom_path', text=f'Use custom Mitsuba path (Supported version is v{DEPS_MITSUBA_VERSION})')
         if self.using_mitsuba_custom_path:
             box.prop(self, 'mitsuba_custom_path')
         


### PR DESCRIPTION
When installing dependencies from pip, the latest package is always installed. This can create bugs that cannot be catched by CI as they are not controlled by the environment.

In order to mitigate this, we define a supported version that is enforced in order for the add-on to register. Note that custom Mitsuba versions are not affected by this and one can always use any custom built versions of Mitsuba with the add-on.

This addresses #40 and #41, as well as potentially fixing #38.