### PR TITLE
Handle 'Seperate Color' nodes

### DIFF
--- a/mitsuba-blender/io/exporter/materials.py
+++ b/mitsuba-blender/io/exporter/materials.py
@@ -26,6 +26,9 @@ def convert_float_texture_node(export_ctx, socket):
     if socket.is_linked:
         node = socket.links[0].from_node
 
+        if node.type == "SEPARATE_COLOR":
+            node = node.inputs[0].links[0].from_node
+
         if node.type == "TEX_IMAGE":
             params = export_texture_node(export_ctx, node)
         else:


### PR DESCRIPTION
I tried importing the sponza glTF model into Blender and then exporting it to mitsuba, but it failed to export the materials properly because they're using 'Seperate Color' nodes to split the metallic/roughness textures apart:

![20221207_20h32m05s_grim](https://user-images.githubusercontent.com/13566135/206278178-011c1211-b5da-499c-ba96-ac15db3b3b5c.png)

This PR does a rather hacky redirect of the node to it's input image and materials now get exported. I'm not sure if they're correct though, because I don't know what format Mitsuba expects metallic or roughness textures to be in. Perhaps it would be better to extract the channel that the colour is being separated from and save them as greyscale images?