### PR TITLE
Get CI tests working

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,11 @@ jobs:
         environment:
         - {
           os: "ubuntu-latest",
-          mitsuba-version: "3.4.0"
+          mitsuba-version: "3.4.1"
         }
         - {
           os: "windows-latest",
-          mitsuba-version: "3.4.0"
+          mitsuba-version: "3.4.1"
         }
         blender:
         - {

--- a/mitsuba-blender/__init__.py
+++ b/mitsuba-blender/__init__.py
@@ -22,7 +22,7 @@ import subprocess
 
 from . import io, engine
 
-DEPS_MITSUBA_VERSION = '3.4.0'
+DEPS_MITSUBA_VERSION = '3.4.1'
 
 def get_addon_preferences(context):
     return context.preferences.addons[__name__].preferences

--- a/mitsuba-blender/engine/properties.py
+++ b/mitsuba-blender/engine/properties.py
@@ -235,7 +235,7 @@ def create_plugin_props(name, arg_dict, depth=1, prefix=""):
 
     def to_dict(self):
         '''
-        Function that converts the plugin into a dict that can be loaded or savec by mitsuba's API
+        Function that converts the plugin into a dict that can be loaded or saved by mitsuba's API
         '''
         plugin_params = {'type' : name}
         if 'parameters' in self.args:
@@ -249,7 +249,8 @@ def create_plugin_props(name, arg_dict, depth=1, prefix=""):
                     list_type = param['values_type']
                     if list_type == 'integrator':
                         for integrator in self.integrators.collection:
-                            plugin_params[integrator.name] = getattr(integrator.available_integrators, integrator.active_integrator).to_dict()
+                            # Make sure we don't have any leading underscores for names - Mitsuba will otherwise complain!
+                            plugin_params[integrator.name.lstrip('_')] = getattr(integrator.available_integrators, integrator.active_integrator).to_dict()
                     elif list_type == 'string':
                         selected_items = []
                         for choice in param['choices']:

--- a/mitsuba-blender/io/exporter/export_context.py
+++ b/mitsuba-blender/io/exporter/export_context.py
@@ -98,7 +98,7 @@ class ExportContext:
                 del mts_dict['id']
 
             except KeyError:
-                name = '__elm__%i' % self.counter
+                name = 'elm__%i' % self.counter
 
         self.scene_data.update([(name, mts_dict)])
         self.counter += 1

--- a/mitsuba-blender/io/exporter/materials.py
+++ b/mitsuba-blender/io/exporter/materials.py
@@ -32,7 +32,8 @@ def convert_float_texture_node(export_ctx, socket):
             raise NotImplementedError( "Node type %s is not supported. Only texture nodes are supported for float inputs" % node.type)
 
     else:
-        if socket.name == 'Roughness':#roughness values in blender are remapped with a square root
+        #roughness values in blender are remapped with a square root
+        if 'Roughness' in socket.name:
             params = pow(socket.default_value, 2)
         else:
             params = socket.default_value
@@ -271,12 +272,6 @@ def convert_principled_materials_cycles(export_ctx, current_node):
     sheen_tint = convert_float_texture_node(export_ctx, current_node.inputs['Sheen Tint'])
     clearcoat = convert_float_texture_node(export_ctx, current_node.inputs['Clearcoat'])
     clearcoat_roughness = convert_float_texture_node(export_ctx, current_node.inputs['Clearcoat Roughness'])
-
-    # Undo default roughness transform done by the exporter
-    if type(roughness) is float:
-        roughness = np.sqrt(roughness)
-    if type(clearcoat_roughness) is float:
-        clearcoat_roughness = np.sqrt(clearcoat_roughness)
 
     params.update({
         'type': 'principled',

--- a/mitsuba-blender/io/importer/mi_spectra_utils.py
+++ b/mitsuba-blender/io/importer/mi_spectra_utils.py
@@ -30,7 +30,7 @@ def convert_mi_srgb_reflectance_spectrum(mi_obj, default):
 #######################
 
 def convert_mi_srgb_emitter_spectrum(mi_obj, default):
-    assert mi_obj.class_().name() == 'SRGBEmitterSpectrum'
+    assert mi_obj.class_().name() == 'SRGBReflectanceSpectrum'
     obj_props = _get_mi_obj_properties(mi_obj)
     radiance = list(obj_props.get('value', default))
     return get_color_strength_from_radiance(radiance)

--- a/mitsuba-blender/io/importer/renderer.py
+++ b/mitsuba-blender/io/importer/renderer.py
@@ -190,7 +190,7 @@ def apply_mi_independent_properties(mi_context, mi_props):
     bl_independent_props.sample_count = mi_props.get('sample_count', 4)
     bl_independent_props.seed = mi_props.get('seed', 0)
     # Cycles properties
-    bl_renderer.sampling_pattern = 'SOBOL'
+    bl_renderer.sampling_pattern = 'SOBOL' if bpy.app.version < (3, 5, 0) else 'SOBOL_BURLEY'
     bl_renderer.samples = mi_props.get('sample_count', 4)
     bl_renderer.preview_samples = mi_props.get('sample_count', 4)
     bl_renderer.seed = mi_props.get('seed', 0)
@@ -210,7 +210,7 @@ def apply_mi_stratified_properties(mi_context, mi_props):
     bl_stratified_props.jitter = mi_props.get('jitter', True)
     # Cycles properties
     # NOTE: There isn't any equivalent sampler in Blender. We use the default Sobol pattern.
-    bl_renderer.sampling_pattern = 'SOBOL'
+    bl_renderer.sampling_pattern = 'SOBOL' if bpy.app.version < (3, 5, 0) else 'SOBOL_BURLEY'
     bl_renderer.samples = mi_props.get('sample_count', 4)
     bl_renderer.seed = mi_props.get('seed', 0)
     return True
@@ -228,7 +228,12 @@ def apply_mi_multijitter_properties(mi_context, mi_props):
     bl_multijitter_props.seed = mi_props.get('seed', 0)
     bl_multijitter_props.jitter = mi_props.get('jitter', True)
     # Cycles properties
-    bl_renderer.sampling_pattern = 'CORRELATED_MUTI_JITTER' if bpy.app.version < (3, 0, 0) else 'PROGRESSIVE_MULTI_JITTER'
+    if bpy.app.version < (3, 0, 0):
+        bl_renderer.sampling_pattern = 'CORRELATED_MUTI_JITTER'
+    elif bpy.app.version < (3, 5, 0):
+        bl_renderer.sampling_pattern = 'PROGRESSIVE_MULTI_JITTER'
+    else:
+        bl_renderer.sampling_pattern = 'TABULATED_SOBOL'
     bl_renderer.samples = mi_props.get('sample_count', 4)
     bl_renderer.seed = mi_props.get('seed', 0)
     return True

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -66,8 +66,10 @@ class MitsubaSceneRenderer:
                 b_root = b_root.convert(Bitmap.PixelFormat.XYZ, Struct.Type.Float32, False)
             return np.array(b_root, copy=True), None
         else:
-            img = np.array(split[1][1], copy=False)
-            img_m2 = np.array(split[2][1], copy=False)
+            # Check which split contains moments - it may not be the first one after root
+            m2_index = 1 if split[1][0].startswith('m2_') else 2
+            img = np.array(split[m2_index][1], copy=False)
+            img_m2 = np.array(split[m2_index][1], copy=False)
             return img, img_m2 - img * img
 
     def render_scene(self, scene_file, **kwargs):


### PR DESCRIPTION
- few fixes to get end-to-end tests working
- some enums changes in sampling pattern as of 3.5+
- for Windows 3.5+, the new release of Mitsuba ensures we avoid OpenEXR dll collisions (see [here](https://github.com/mitsuba-renderer/mitsuba3/pull/929) for more details)