### PR TITLE
Adds material baking option to Addon

### DIFF
--- a/mitsuba-blender/io/__init__.py
+++ b/mitsuba-blender/io/__init__.py
@@ -185,7 +185,7 @@ class ExportMitsuba(bpy.types.Operator, ExportHelper):
         #reset the exporter
         self.reset()
         end = time.time()
-        print(f"Export took {end-start}")
+        self.converter.export_ctx.log(f"Export took {end-start}")
         return {'FINISHED'}
 
 

--- a/mitsuba-blender/io/exporter/__init__.py
+++ b/mitsuba-blender/io/exporter/__init__.py
@@ -77,8 +77,7 @@ class SceneConverter:
         for object_instance in depsgraph.object_instances:
             window_manager.progress_update(progress_counter)
             progress_counter += 1
-            print(f"Progress: {progress_counter/len(depsgraph.object_instances)}")
-
+            
             if self.use_selection:
                 #skip if it's not selected or if it's an instance and the parent object is not selected
                 if not object_instance.is_instance and not object_instance.object.original.select_get():
@@ -94,7 +93,7 @@ class SceneConverter:
                 and evaluated_obj.parent and evaluated_obj.parent.original.hide_render):
                 self.export_ctx.log("Object: {} is hidden for render. Ignoring it.".format(evaluated_obj.name), 'INFO')
                 continue#ignore it since we don't want it rendered (TODO: hide_viewport)
-            if object_type in {'MESH', 'FONT', 'SURFACE', 'META'}:
+            if object_type in {'MESH', 'FONT', 'SURFACE', 'META'} and evaluated_obj.name in bpy.context.view_layer.objects:
                 geometry.export_object(object_instance, self.export_ctx, evaluated_obj.name in particles)
             elif object_type == 'CAMERA':
                 # When rendering inside blender, export only the active camera

--- a/mitsuba-blender/io/exporter/__init__.py
+++ b/mitsuba-blender/io/exporter/__init__.py
@@ -77,6 +77,7 @@ class SceneConverter:
         for object_instance in depsgraph.object_instances:
             window_manager.progress_update(progress_counter)
             progress_counter += 1
+            print(f"Progress: {progress_counter/len(depsgraph.object_instances)}")
 
             if self.use_selection:
                 #skip if it's not selected or if it's an instance and the parent object is not selected

--- a/mitsuba-blender/io/exporter/export_context.py
+++ b/mitsuba-blender/io/exporter/export_context.py
@@ -68,6 +68,11 @@ class ExportContext:
         self.counter = 0 # Counter to create unique IDs.
         self.exported_mats = ExportedMaterialsCache()
         self.export_ids = False # Export Object IDs in the XML file
+        self.bake_materials = False
+        self.bake_res_x = 1024
+        self.bake_res_y = 1024
+        self.bake_mat_ids = False
+        self.bake_again = True
         self.exported_ids = set()
         # All the args defined below are set in the Converter
         self.directory = ''
@@ -160,6 +165,13 @@ class ExportContext:
         image.filepath_raw = old_filepath
         return f"{self.subfolders['texture']}/{name}"
 
+    def blackbody(self, value):
+        param = {
+            "type" : "blackbody",
+            "temperature" : value
+        }
+        return param
+
     def spectrum(self, value, mode='rgb'):
         '''
         Given a spectrum value, format it for the scene dict.
@@ -185,7 +197,7 @@ class ExportContext:
             if any(type(value[i]) != type(value[i+1]) for i in range(len(value)-1)):
                 raise ValueError("Mixed types in spectrum entry %s" % value)
             totitems = len(value)
-            if isinstance(value[0], (float, int)):
+            if  (value[0], (float, int)):
                 if totitems == 3 or totitems == 4:
                     spec = {
                         'type': 'rgb',

--- a/mitsuba-blender/io/exporter/export_context.py
+++ b/mitsuba-blender/io/exporter/export_context.py
@@ -79,6 +79,7 @@ class ExportContext:
             'shape': 'meshes',
             'spectrum': 'spectra'
                             }
+        self.texture_id = 0
 
 
     def data_add(self, mts_dict, name=''):

--- a/mitsuba-blender/io/exporter/export_context.py
+++ b/mitsuba-blender/io/exporter/export_context.py
@@ -84,7 +84,6 @@ class ExportContext:
             'shape': 'meshes',
             'spectrum': 'spectra'
                             }
-        self.texture_id = 0
 
 
     def data_add(self, mts_dict, name=''):
@@ -197,7 +196,7 @@ class ExportContext:
             if any(type(value[i]) != type(value[i+1]) for i in range(len(value)-1)):
                 raise ValueError("Mixed types in spectrum entry %s" % value)
             totitems = len(value)
-            if  (value[0], (float, int)):
+            if isinstance(value[0], (float, int)):
                 if totitems == 3 or totitems == 4:
                     spec = {
                         'type': 'rgb',

--- a/mitsuba-blender/io/exporter/geometry.py
+++ b/mitsuba-blender/io/exporter/geometry.py
@@ -1,8 +1,7 @@
-from .materials import export_material
-from .export_context import Files
-from mathutils import Matrix
 import os
 import bpy
+from .materials import export_material
+from .export_context import Files
 
 def convert_mesh(export_ctx, b_mesh, matrix_world, name, mat_nr):
     '''
@@ -103,7 +102,7 @@ def export_object(deg_instance, export_ctx, is_particle):
     # Remove spurious characters such as slashes
     name_clean = bpy.path.clean_name(b_object.name_full)
     object_id = f"mesh-{name_clean}"
-    print(f"Exporting object {name_clean}")
+    export_ctx.log(f"Exporting object {name_clean}")
     is_instance_emitter = b_object.parent is not None and b_object.parent.is_instancer
     is_instance = deg_instance.is_instance
     # Only write to file objects that have never been exported before

--- a/mitsuba-blender/io/exporter/materials.py
+++ b/mitsuba-blender/io/exporter/materials.py
@@ -2,7 +2,6 @@ import numpy as np
 import bpy
 from mathutils import Matrix
 from .export_context import Files
-from .nodes.material_evaluator import traverse
 import time
 import os.path
 
@@ -495,8 +494,6 @@ def b_material_to_dict(export_ctx, b_mat, obj_name):
             output_node_id = 'Material Output'
             if output_node_id in b_mat.node_tree.nodes:
                 # Save output node for baking
-                # output_node = b_mat.node_tree.nodes[output_node_id]
-                # surface_node = output_node.inputs["Surface"].links[0].from_node
                 
                 surface_node = get_surface_node(b_mat).links[0].from_node
                 mat_params = cycles_material_to_dict(export_ctx, surface_node, b_mat, obj_name)


### PR DESCRIPTION
# Texture baking for Blender Materials

All the textures are baked for each of the BSDF inputs. The new algorithm takes a BSDF and bakes textures for inputs such as Base Color, Roughness and others.

## New options:
- Texture baking. BSDF inputs are now baked as textures
- Incremental baking (bake textures again). Does not bake textures again if disabled.
- Texture baking resolution. Custom resolution for texture baking in the export options.
- Unique material IDs for each baked texture. Some objects and materials can overlap, with unique IDs each object has unique material in Mitsuba XML export. Useful when the final textures are broken.
