### PR TITLE
Remove 'SHARP' distribution type for non-rough conductor/dielectric surfaces

### DIFF
--- a/mitsuba-blender/io/exporter/materials.py
+++ b/mitsuba-blender/io/exporter/materials.py
@@ -105,7 +105,7 @@ def convert_glossy_materials_cycles(export_ctx, current_node):
 
     roughness = convert_float_texture_node(export_ctx, current_node.inputs['Roughness'])
 
-    if roughness and current_node.distribution != 'SHARP':
+    if roughness > 0:
         params.update({
             'type': 'roughconductor',
             'alpha': roughness,


### PR DESCRIPTION
Blender 4.0 changed the way clear dielectric and conductor surfaces are handled, using only the roughness field now. This PR changes the import/export accordingly. This fixes #99 