### PR TITLE
Fix power to radiance conversion

### DIFF
--- a/mitsuba-blender/io/exporter/lights.py
+++ b/mitsuba-blender/io/exporter/lights.py
@@ -43,8 +43,8 @@ def convert_area_light(b_light, export_ctx):
     emitter = {
         'type': 'area'
     }
-    # Conversion factor used in Cycles, to convert to irradiance (don't ask me why)
-    conv_fac = 1.0 / (area * 4.0)
+    # Conversion factor to convert power to radiance.
+    conv_fac = 1.0 / (area * np.pi)
     emitter['radiance'] = export_ctx.spectrum(conv_fac * b_light.data.energy * b_light.data.color)
     params['emitter'] = emitter
 


### PR DESCRIPTION
With Blender 4.x, they at some point fixed their faulty conversion from power to radiance. They had a factor of 4 in that, where it should have been pi instead: https://projects.blender.org/blender/blender/issues/109404

This PR adjusts the exporter to now export according to the new, fixed convention.

Here some validation renderings. It's best to just download these and compare in TEV:

Blender Cycles rendering:
![image](https://github.com/user-attachments/assets/5c088f80-3948-4bf2-86a6-ce1d7c0177cd)

Mitsuba rendering with current exporter:
![image](https://github.com/user-attachments/assets/9c8a82f0-f5d0-4bdf-aa94-9456ef2a2706)

Mitsuba rendering with fixed exporter:
![image](https://github.com/user-attachments/assets/02cbe724-a90b-461c-be0c-926966699d20)

I think the area light is the only case that is affected. How much is backwards compatibility a consideration here? For full backwards compatibility, we would have to make this scaling conditional on the precise version of Blender where this changed (not sure which one that is)
