### PR TITLE
Fix importer issues for Blender 4.x

### DIFF
--- a/mitsuba-blender/io/importer/renderer.py
+++ b/mitsuba-blender/io/importer/renderer.py
@@ -190,7 +190,7 @@ def apply_mi_independent_properties(mi_context, mi_props):
     bl_independent_props.sample_count = mi_props.get('sample_count', 4)
     bl_independent_props.seed = mi_props.get('seed', 0)
     # Cycles properties
-    bl_renderer.sampling_pattern = 'SOBOL' if bpy.app.version < (3, 5, 0) else 'SOBOL_BURLEY'
+    bl_renderer.sampling_pattern = 'SOBOL' if bpy.app.version < (3, 5, 0) else ('SOBOL_BURLEY' if bpy.app.version < (4, 0, 0) else 'AUTOMATIC')
     bl_renderer.samples = mi_props.get('sample_count', 4)
     bl_renderer.preview_samples = mi_props.get('sample_count', 4)
     bl_renderer.seed = mi_props.get('seed', 0)
@@ -210,7 +210,7 @@ def apply_mi_stratified_properties(mi_context, mi_props):
     bl_stratified_props.jitter = mi_props.get('jitter', True)
     # Cycles properties
     # NOTE: There isn't any equivalent sampler in Blender. We use the default Sobol pattern.
-    bl_renderer.sampling_pattern = 'SOBOL' if bpy.app.version < (3, 5, 0) else 'SOBOL_BURLEY'
+    bl_renderer.sampling_pattern = 'SOBOL' if bpy.app.version < (3, 5, 0) else ('SOBOL_BURLEY' if bpy.app.version < (4, 0, 0) else 'AUTOMATIC')
     bl_renderer.samples = mi_props.get('sample_count', 4)
     bl_renderer.seed = mi_props.get('seed', 0)
     return True

--- a/mitsuba-blender/io/importer/shapes.py
+++ b/mitsuba-blender/io/importer/shapes.py
@@ -35,7 +35,8 @@ def _set_bl_mesh_shading(bl_mesh, flat_shading=True, flip_normals=False):
     if flat_shading:
         bl_mesh.polygons.foreach_set('use_smooth', [False] * len(bl_mesh.polygons))
     else:
-        bl_mesh.calc_normals()
+        if bpy.app.version < (4, 0, 0):
+            bl_mesh.calc_normals()
         bl_mesh.polygons.foreach_set('use_smooth', [True] * len(bl_mesh.polygons))
     if flip_normals:
         bl_mesh.flip_normals()


### PR DESCRIPTION
1. Updated Cycles Sampling Pattern Logic (renderer.py):
- Problem: Blender 4.0+ removed 'SOBOL_BURLEY' as a valid enum option for the Cycles sampling_pattern. The previous logic, which defaulted to 'SOBOL_BURLEY' for Blender 3.5+, would cause a TypeError in Blender 4.x.
- Fix: Use 'AUTOMATIC' for Blender versions >= (4, 0, 0).

4. Conditional Mesh Normal Calculation (shapes.py):
- Problem: The bl_mesh.calc_normals() method has been removed from the Blender Python API in version 4.x. Calling it results in an AttributeError.
- Fix: The explicit call to bl_mesh.calc_normals() is now conditional:It is only called if bpy.app.version < (4, 0, 0).
