### PR TITLE
Show log messages in Blender's info log window.

### DIFF
--- a/mitsuba-blender/io/__init__.py
+++ b/mitsuba-blender/io/__init__.py
@@ -58,7 +58,7 @@ class ImportMistuba(bpy.types.Operator, ImportHelper):
         collection = scene.collection
 
         try:
-            importer.load_mitsuba_scene(context, scene, collection, self.filepath, axis_mat)
+            importer.load_mitsuba_scene(self, context, scene, collection, self.filepath, axis_mat)
         except (RuntimeError, NotImplementedError) as e:
             print(e)
             self.report({'ERROR'}, "Failed to load Mitsuba scene. See error log.")
@@ -109,7 +109,7 @@ class ExportMitsuba(bpy.types.Operator, ExportHelper):
         self.reset()
 
     def reset(self):
-        self.converter = exporter.SceneConverter()
+        self.converter = exporter.SceneConverter(self)
 
     def execute(self, context):
         # Conversion matrix to shift the "Up" Vector. This can be useful when exporting single objects to an existing mitsuba scene.

--- a/mitsuba-blender/io/exporter/__init__.py
+++ b/mitsuba-blender/io/exporter/__init__.py
@@ -26,8 +26,8 @@ class SceneConverter:
     Converts a blender scene to a Mitsuba-compatible dict.
     Either save it as an XML or load it as a scene.
     '''
-    def __init__(self, render=False):
-        self.export_ctx = export_context.ExportContext()
+    def __init__(self, export_helper, render=False):
+        self.export_ctx = export_context.ExportContext(export_helper)
         self.use_selection = False # Only export selection
         self.ignore_background = True
         self.render = render

--- a/mitsuba-blender/io/exporter/export_context.py
+++ b/mitsuba-blender/io/exporter/export_context.py
@@ -63,7 +63,7 @@ class ExportContext:
     Export Context
     '''
 
-    def __init__(self):
+    def __init__(self, export_helper):
         self.scene_data = OrderedDict([('type','scene')])
         self.counter = 0 # Counter to create unique IDs.
         self.exported_mats = ExportedMaterialsCache()
@@ -79,6 +79,7 @@ class ExportContext:
             'shape': 'meshes',
             'spectrum': 'spectra'
                             }
+        self.export_helper = export_helper
 
 
     def data_add(self, mts_dict, name=''):
@@ -126,8 +127,18 @@ class ExportContext:
             'ERROR': LogLevel.Error,
             'TRACE': LogLevel.Trace
             }
+        log_level_blender = {
+            'DEBUG': 'DEBUG',
+            'INFO': 'INFO',
+            'WARN': 'WARNING',
+            'ERROR': 'ERROR',
+            'TRACE': 'INFO'
+            }
+
         if level not in log_level:
             raise ValueError("Invalid logging level '%s'!" % level)
+
+        self.export_helper.report({log_level_blender[level]}, message)
         Log(log_level[level], message)
 
     def export_texture(self, image):

--- a/mitsuba-blender/io/importer/__init__.py
+++ b/mitsuba-blender/io/importer/__init__.py
@@ -363,7 +363,7 @@ def instantiate_bl_data_node(mi_context, bl_node):
 ##    Main loading     ##
 #########################
 
-def load_mitsuba_scene(bl_context, bl_scene, bl_collection, filepath, global_mat):
+def load_mitsuba_scene(import_helper, bl_context, bl_scene, bl_collection, filepath, global_mat):
     ''' Load a Mitsuba scene from an XML file into a Blender scene.
     
     Params
@@ -379,7 +379,7 @@ def load_mitsuba_scene(bl_context, bl_scene, bl_collection, filepath, global_mat
     from mitsuba import xml_to_props
     raw_props = xml_to_props(filepath)
     mi_scene_props = common.MitsubaSceneProperties(raw_props)
-    mi_context = common.MitsubaSceneImportContext(bl_context, bl_scene, bl_collection, filepath, mi_scene_props, global_mat)
+    mi_context = common.MitsubaSceneImportContext(import_helper, bl_context, bl_scene, bl_collection, filepath, mi_scene_props, global_mat)
 
     _, mi_props = mi_scene_props.get_first_of_class('Scene')
     bl_scene_data_node = mi_props_to_bl_data_node(mi_context, 'Scene', mi_props)

--- a/mitsuba-blender/io/importer/common.py
+++ b/mitsuba-blender/io/importer/common.py
@@ -201,7 +201,8 @@ class MitsubaSceneProperties:
 
 class MitsubaSceneImportContext:
     ''' Define a context for the Mitsuba scene importer '''
-    def __init__(self, bl_context, bl_scene, bl_collection, filepath, mi_scene_props, axis_matrix):
+    def __init__(self, import_helper, bl_context, bl_scene, bl_collection, filepath, mi_scene_props, axis_matrix):
+        self.import_helper = import_helper
         self.bl_context = bl_context
         self.bl_scene = bl_scene
         self.bl_collection = bl_collection
@@ -231,8 +232,18 @@ class MitsubaSceneImportContext:
             'ERROR': LogLevel.Error,
             'TRACE': LogLevel.Trace
             }
+        log_level_blender = {
+            'DEBUG': 'DEBUG',
+            'INFO': 'INFO',
+            'WARN': 'WARNING',
+            'ERROR': 'ERROR',
+            'TRACE': 'INFO'
+            }
+
         if level not in log_level:
             raise ValueError("Invalid logging level '%s'!" % level)
+
+        self.import_helper.report({log_level_blender[level]}, message)
         Log(log_level[level], message)
 
     def bl_space_to_mi_space(self, matrix):


### PR DESCRIPTION
This pull request adds functionality to the exporter and importer allowing to show the log messages in Blender, removing the need of running Blender from the command line to be able to see these messages.

With this addition, the log messages are shown as a popup.
<img width="285" height="92" alt="blender_error_popup" src="https://github.com/user-attachments/assets/b63d83d0-a8ca-4951-8af2-354d8fe6d56a" />

They can also be checked in the Info Log window, allowing proper inspection of the errors and warnings integrated in Blender.
<img width="383" height="62" alt="blender_error_infolog" src="https://github.com/user-attachments/assets/d6d50d5d-d75c-42d1-bb34-c3820a63f639" />

