### PR TITLE
Fix ExportMitsuba init for Blender 5.0 compatibility

### DIFF
--- a/mitsuba-blender/io/__init__.py
+++ b/mitsuba-blender/io/__init__.py
@@ -104,8 +104,8 @@ class ExportMitsuba(bpy.types.Operator, ExportHelper):
             default = True
     )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self):
+        super().__init__()
         self.reset()
 
     def reset(self):


### PR DESCRIPTION
## Summary

Fixes the `TypeError: ExportMitsuba.__init__() takes 1 positional argument but 2 were given` error when exporting in Blender 5.0+.

Blender 5.0 changed how operator constructors work — `Operator.__init__()` no longer accepts arbitrary positional/keyword arguments. The `*args, **kwargs` in the `ExportMitsuba.__init__` signature caused the mismatch. Since `Operator.__init__` has always only taken `self`, the varargs were unnecessary.

Fixes #146